### PR TITLE
Use container to instantiate non-eloquent objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 All notable changes to the Laravel Mail Viewer be documented in this file
 
+## v2.0.1 (28-09-2018)
+- The package now attempts to instantiate non eloquent objects using the container if no factory exists.
+
 ## v2.0.0 (27-09-2018)
 - Major changes in how the mailables are registered in the config file.
 - Please read the comments in the config file for the 'mailable' key and update yours accordingly.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ composer require joggapp/laravel-mail-viewer
 
 The package will automatically register itself.
 
-You will have to add the mailables and configure the other settings using the package's config file in order to to use this package. You can publish the config file with:
+You will have to add the mailables and configure the other settings using the package's config file in order to to use this package. Please read the comments/description for each config key thoroughly and set their values. You can publish the config file with:
 
 ```bash
 php artisan vendor:publish --provider="JoggApp\MailViewer\MailViewerServiceProvider"
@@ -41,8 +41,16 @@ return [
     |
     | The package will look for the equivalent factory if the
     | dependency is an eloquent model. So don't forget to
-    | create those factories. Also, don't forget to import
-    | these classes at the top :)
+    | create those factories. However, things like the factory
+    | state & times/count feature aren't supported for the factories.
+    | Eg:
+    | What the package supports: factory(Order::class)->create();
+    | What the package doesn't support: factory(Order::class, 5)->state('pending')->create();
+    |
+    | The package will try to resolve all other non-eloquent objects
+    | using the Laravel's service container.
+    |
+    | Also, don't forget to import these classes at the top :)
     |
     | eg: 'mailables' => [
     |       OrderShipped::class => [

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "require": {
         "php": "^7.1",
         "illuminate/routing": "5.6.*|5.7.*",
-        "illuminate/support": "5.6.*|5.7.*"
+        "illuminate/support": "5.6.*|5.7.*",
+        "illuminate/database": "5.6.*|5.7.*"
     },
     "require-dev": {
         "mockery/mockery": "^1.1",

--- a/config/mailviewer.php
+++ b/config/mailviewer.php
@@ -16,8 +16,16 @@ return [
     |
     | The package will look for the equivalent factory if the
     | dependency is an eloquent model. So don't forget to
-    | create those factories. Also, don't forget to import
-    | these classes at the top :)
+    | create those factories. However, things like the factory
+    | state & times/count feature aren't supported for the factories.
+    | Eg:
+    | What the package supports: factory(Order::class)->create();
+    | What the package doesn't support: factory(Order::class, 5)->state('pending')->create();
+    |
+    | The package will try to resolve all other non-eloquent objects
+    | using the Laravel's service container.
+    |
+    | Also, don't forget to import these classes at the top :)
     |
     | eg: 'mailables' => [
     |       OrderShipped::class => [

--- a/tests/MailViewerTest.php
+++ b/tests/MailViewerTest.php
@@ -33,9 +33,16 @@ class MailViewerTest extends BaseTestCase
     }
 
     /** @test */
-    public function it_renders_the_mailable_on_its_dedicated_route()
+    public function it_renders_the_mailable_without_dependencies_on_its_dedicated_route()
     {
         $this->get(route('mv-mailviewer', 'TestEmailForMailViewer'))
+            ->assertSee('The test email view');
+    }
+
+    /** @test */
+    public function it_renders_the_mailable_with_dependencies_on_its_dedicated_route()
+    {
+        $this->get(route('mv-mailviewer', 'TestEmailWithDependencies'))
             ->assertSee('The test email view');
     }
 }


### PR DESCRIPTION
- The package now attempts to instantiate non eloquent objects using the container if no factory exists.
- Improved the docs & tests.