### PR TITLE
Move loading of factories to the base test class

### DIFF
--- a/src/MailViewerServiceProvider.php
+++ b/src/MailViewerServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace JoggApp\MailViewer;
 
-use Illuminate\Database\Eloquent\Factory as EloquentFactory;
 use Illuminate\Support\ServiceProvider;
 
 class MailViewerServiceProvider extends ServiceProvider
@@ -16,15 +15,6 @@ class MailViewerServiceProvider extends ServiceProvider
         $this->loadRoutesFrom(__DIR__ . '/../routes/web.php');
 
         $this->loadViewsFrom(__DIR__ . '/../views', 'mailviewer');
-
-        if (app()->environment() === 'testing') {
-            $this->app->singleton(EloquentFactory::class, function ($app) {
-                $faker = $app->make(\Faker\Generator::class);
-                $factories_path = __DIR__.'/../tests/Factories';
-
-                return EloquentFactory::construct($faker, $factories_path);
-            });
-        }
     }
 
     public function register()

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -2,6 +2,7 @@
 
 namespace JoggApp\MailViewer\Tests;
 
+use Illuminate\Database\Eloquent\Factory as EloquentFactory;
 use JoggApp\MailViewer\MailViewerServiceProvider;
 use JoggApp\MailViewer\Tests\Stubs\Mail\TestEmailForMailViewer;
 use JoggApp\MailViewer\Tests\Stubs\Mail\TestEmailWithDependencies;
@@ -42,5 +43,12 @@ class BaseTestCase extends TestCase
         $app['config']->set('mailviewer.url', 'mails');
         $app['config']->set('mailviewer.allowed_environments', ['local', 'staging', 'testing']);
         $app['config']->set('mailviewer.middlewares', []);
+
+        $app->singleton(EloquentFactory::class, function ($app) {
+            $faker = $app->make(\Faker\Generator::class);
+            $factories_path = __DIR__ . '/Factories';
+
+            return EloquentFactory::construct($faker, $factories_path);
+        });
     }
 }


### PR DESCRIPTION
Loading of custom factory for the tests in the service provider was causing problems when running unit tests as part of a project. Moving this logic to the base test class solves this problem.