### PR TITLE
Fix issue with ReflectionParameter (fixes #14)

### DIFF
--- a/src/MailViewer.php
+++ b/src/MailViewer.php
@@ -97,10 +97,15 @@ class MailViewer
 
             $constructorParameters = [];
 
-            foreach ($reflection->getConstructor()->getParameters() as $parameter) {
+            for($i = 0; $i < count( $reflection->getConstructor()->getParameters()); $i++) {
+                $parameter = $reflection->getConstructor()->getParameters()[$i];
+                if (empty($parameter->getType())) {
+                    $constructorParameters[$i] =  $givenParameters[$i];
+                    continue;
+                }
                 $constructorParameters[] = $parameter->getType()->getName() == 'int' ? 'integer' : $parameter->getType()->getName();
             }
-
+            
             if ($constructorParameters !== $givenParameters) {
                 throw new Exception(
                     "The arguments passed for {$mailable} in the config/mailviewer.php file do not match with the constructor


### PR DESCRIPTION
The original code 
```php
$constructorParameters[] = $parameter->getType()->getName() == 'int' ? 'integer' : $parameter->getType()->getName();
```
has error because not all `$parameter` has a `getType` method (which are PHP's native types, such as int, bool etc.); this fixes it, by looping it thru, and it does not have `getType`, it will just take it from `givenParameters`; this is fine, because native PHP types are very flexible, and it will not cause error ( passing 3 as int, string or bool doesn't cause error )