### PR TITLE
add check for constructor method

### DIFF
--- a/src/MailViewer.php
+++ b/src/MailViewer.php
@@ -97,15 +97,17 @@ class MailViewer
 
             $constructorParameters = [];
 
-            for ($i = 0; $i < count($reflection->getConstructor()->getParameters()); $i++) {
-                $parameter = $reflection->getConstructor()->getParameters()[$i];
+            if ($reflection->getConstructor()) {
+                for ($i = 0; $i < count($reflection->getConstructor()->getParameters()); $i++) {
+                    $parameter = $reflection->getConstructor()->getParameters()[$i];
 
-                if (empty($parameter->getType())) {
-                    $constructorParameters[$i] = $givenParameters[$i];
-                    continue;
+                    if (empty($parameter->getType())) {
+                        $constructorParameters[$i] = $givenParameters[$i];
+                        continue;
+                    }
+
+                    $constructorParameters[] = $parameter->getType()->getName() == 'int' ? 'integer' : $parameter->getType()->getName();
                 }
-
-                $constructorParameters[] = $parameter->getType()->getName() == 'int' ? 'integer' : $parameter->getType()->getName();
             }
 
             if ($constructorParameters !== $givenParameters) {

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -7,6 +7,7 @@ use JoggApp\MailViewer\Tests\Stubs\Mail\NamespaceOne\TestEmail as TestEmailInNam
 use JoggApp\MailViewer\Tests\Stubs\Mail\NamespaceTwo\TestEmail as TestEmailInNamespaceTwo;
 use JoggApp\MailViewer\Tests\Stubs\Mail\TestEmailForMailViewer;
 use JoggApp\MailViewer\Tests\Stubs\Mail\TestEmailWithDependencies;
+use JoggApp\MailViewer\Tests\Stubs\Mail\TestEmailWithNoConstructor;
 use JoggApp\MailViewer\Tests\Stubs\Mail\TestEmailWithState;
 use JoggApp\MailViewer\Tests\Stubs\Models\Test;
 use Orchestra\Testbench\TestCase;
@@ -40,6 +41,7 @@ class BaseTestCase extends TestCase
             'mailviewer.mailables',
             [
                 TestEmailForMailViewer::class => [],
+                TestEmailWithNoConstructor::class => [],
                 TestEmailWithDependencies::class => [
                     [],
                     \stdClass::class,

--- a/tests/MailViewerTest.php
+++ b/tests/MailViewerTest.php
@@ -2,6 +2,8 @@
 
 namespace JoggApp\MailViewer\Tests;
 
+use JoggApp\MailViewer\MailViewer;
+
 class MailViewerTest extends BaseTestCase
 {
     protected $packageUrl;
@@ -62,5 +64,15 @@ class MailViewerTest extends BaseTestCase
 
         $this->get(route('mv-mailviewer', 'JoggApp\MailViewer\Tests\Stubs\Mail\NamespaceTwo\TestEmail'))
             ->assertSee('The test email view for email in namespace two.');
+    }
+
+    /** @test */
+    public function it_does_not_fail_when_constructor_is_not_declared()
+    {
+        $mailer = MailViewer::prepareMails([
+            'JoggApp\MailViewer\Tests\Stubs\Mail\TestEmailWithNoConstructor' => [],
+        ]);
+
+        $this->assertTrue(true);
     }
 }

--- a/tests/MailViewerTest.php
+++ b/tests/MailViewerTest.php
@@ -2,8 +2,6 @@
 
 namespace JoggApp\MailViewer\Tests;
 
-use JoggApp\MailViewer\MailViewer;
-
 class MailViewerTest extends BaseTestCase
 {
     protected $packageUrl;
@@ -42,6 +40,13 @@ class MailViewerTest extends BaseTestCase
     }
 
     /** @test */
+    public function it_renders_the_mailable_without_dependencies_or_constructor_on_its_dedicated_route()
+    {
+        $this->get('/mails')
+            ->assertSee('All Mails');
+    }
+
+    /** @test */
     public function it_renders_the_mailable_with_dependencies_on_its_dedicated_route()
     {
         $this->get(route('mv-mailviewer', 'JoggApp\MailViewer\Tests\Stubs\Mail\TestEmailWithDependencies'))
@@ -64,15 +69,5 @@ class MailViewerTest extends BaseTestCase
 
         $this->get(route('mv-mailviewer', 'JoggApp\MailViewer\Tests\Stubs\Mail\NamespaceTwo\TestEmail'))
             ->assertSee('The test email view for email in namespace two.');
-    }
-
-    /** @test */
-    public function it_does_not_fail_when_constructor_is_not_declared()
-    {
-        $mailer = MailViewer::prepareMails([
-            'JoggApp\MailViewer\Tests\Stubs\Mail\TestEmailWithNoConstructor' => [],
-        ]);
-
-        $this->assertTrue(true);
     }
 }

--- a/tests/Stubs/Mail/TestEmailWithNoConstructor.php
+++ b/tests/Stubs/Mail/TestEmailWithNoConstructor.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace JoggApp\MailViewer\Tests\Stubs\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class TestEmailWithNoConstructor extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->view('mailviewer::stubs.emailtestview');
+    }
+}


### PR DESCRIPTION
PROBLEM

When a mailable doesn't include a constructor method, calling `$reflection->getConstructor()->getParameters()` throws an exception of `Call to a member function getParameters() on null` due to the fact that there is no constructor.

FIX

Add a simple fix to make sure `$reflection->getConstructor()` is not null. Fixing the problem.